### PR TITLE
Updated code to use latest checkout action

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the GitHub Actions workflow to use the latest version of the checkout action by replacing the specific commit hash with the semantic version tag 'v3'.

CI:
- Update GitHub Actions workflow to use the latest version of the checkout action by switching to the semantic version tag 'v3'.

<!-- Generated by sourcery-ai[bot]: end summary -->