### PR TITLE
Fixed deploy workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      uses: actions/checkout@v3
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Duplicate entries caused workflow to fail

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the deploy workflow by removing duplicate entries and updating action versions in the Docker build workflow configuration.

CI:
- Simplify the Docker build workflow by removing duplicate steps and updating action versions.

<!-- Generated by sourcery-ai[bot]: end summary -->