### PR TITLE
Added logs volume to Docker images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: scraper/Dockerfile
     volumes:
       - json_files:/app/json_files
+      - ./logs:/app/logs
 
   api:
     image: bartczaktech/api:latest
@@ -15,6 +16,7 @@ services:
       dockerfile: api/Dockerfile
     volumes:
       - json_files:/app/json_files
+      - ./logs:/app/logs
     ports:
       - "8000:8000"
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a logs volume to the Docker images in the docker-compose.yml file to enable directory sharing between the host and containers.

Deployment:
- Add a logs volume to the Docker images in the docker-compose.yml file, allowing the sharing of a logs directory between the host and the containers.

<!-- Generated by sourcery-ai[bot]: end summary -->