### PR TITLE
[Refactor] Fixing issue with Docker not pulling the newest image from Docker Hub 

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,6 +38,7 @@ jobs:
         no-cache: true
         tags: |
           bartczaktech/api:${{ env.IMAGE_TAG }}
+          bartczaktech/api:latest
 
     - name: Build and push Scraper Docker image
       uses: docker/build-push-action@v4
@@ -48,6 +49,7 @@ jobs:
         no-cache: true
         tags: |
           bartczaktech/scraper:${{ env.IMAGE_TAG }}
+          bartczaktech/scraper:latest
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,10 +22,32 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
 
-    - name: Build and push Docker images
+    - name: Extract Git commit SHA
+      id: vars
       run: |
-        docker compose -f docker-compose.yml build
-        docker compose -f docker-compose.yml push
+        echo "SHA_SHORT=$(echo $GITHUB_SHA | cut -c1-7)" >> $GITHUB_OUTPUT
+        echo "IMAGE_TAG=${{ steps.vars.outputs.SHA_SHORT }}" >> $GITHUB_ENV
+
+
+    - name: Build and push API Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./api/Dockerfile
+        push: true
+        no-cache: true
+        tags: |
+          bartczaktech/api:${{ env.IMAGE_TAG }}
+
+    - name: Build and push Scraper Docker image
+      uses: docker/build-push-action@v4
+      with:
+        context: .
+        file: ./scraper/Dockerfile
+        push: true
+        no-cache: true
+        tags: |
+          bartczaktech/scraper:${{ env.IMAGE_TAG }}
 
   deploy:
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: '3.8'
 services:
   scraper:
-    image: bartczaktech/scraper:latest
+    image: bartczaktech/scraper:${IMAGE_TAG}
+    restart: always
     build:
       context: .
       dockerfile: scraper/Dockerfile
@@ -10,7 +11,8 @@ services:
       - ./logs:/app/logs
 
   api:
-    image: bartczaktech/api:latest
+    image: bartczaktech/api:${IMAGE_TAG}
+    restart: always
     build:
       context: .
       dockerfile: api/Dockerfile


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the Docker build process to use unique image tags based on the Git commit SHA, ensuring the latest images are pulled. Disable the Docker build cache to guarantee fresh builds. Update the GitHub Actions workflow to support these changes.

Enhancements:
- Use Git commit SHA to generate unique Docker image tags to ensure the latest image is pulled.
- Disable Docker build cache to ensure fresh builds.

CI:
- Update GitHub Actions workflow to extract Git commit SHA and use it for Docker image tagging.

<!-- Generated by sourcery-ai[bot]: end summary -->