### PR TITLE
[Refactor] Fixed context directory in docker-build.yml

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build and push API Docker image
         uses: docker/build-push-action@v4
         with:
-          context: ./api
+          context: .
           file: ./api/Dockerfile
           push: true
           tags: |
@@ -37,7 +37,7 @@ jobs:
       - name: Build and push Scraper Docker image
         uses: docker/build-push-action@v4
         with:
-          context: ./scraper
+          context: .
           file: ./scraper/Dockerfile
           push: true
           tags: |


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the docker-build.yml workflow to set the context directory to the root for building both API and Scraper Docker images.

CI:
- Update the context directory in the docker-build.yml workflow to use the root directory for both API and Scraper Docker image builds.

<!-- Generated by sourcery-ai[bot]: end summary -->