### PR TITLE
[Refactor] Fixed image tags not available for deploy job

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    outputs:
+      IMAGE_TAG: ${{ steps.set-image-tag.outputs.IMAGE_TAG }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -23,6 +25,10 @@ jobs:
 
       - name: Extract Git commit SHA
         run: echo "IMAGE_TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      - name: Set IMAGE_TAG
+        id: set-image-tag
+        run: echo "::set-output name=IMAGE_TAG::${GITHUB_SHA::7}"
 
       - name: Build and push API Docker image
         uses: docker/build-push-action@v4
@@ -47,7 +53,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build-and-push
-
+    env:
+        IMAGE_TAG: ${{ needs.build-and-push.outputs.IMAGE_TAG }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor the CI workflow to ensure the image tag is available for the deploy job by setting and passing the IMAGE_TAG output from the build-and-push job.

CI:
- Add an output for the IMAGE_TAG in the build-and-push job to pass the image tag to the deploy job.

<!-- Generated by sourcery-ai[bot]: end summary -->